### PR TITLE
adding JAVA_HOME directory to gradlew to solve issue with VM not sett…

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -22,6 +22,9 @@
 ##
 ##############################################################################
 
+
+JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
+
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
 PRG="$0"

--- a/src/gatling/conf/gatling.conf
+++ b/src/gatling/conf/gatling.conf
@@ -10,11 +10,12 @@ gatling {
     #runDescription = ""          # The description for this simulation run, displayed in each report
     #encoding = "utf-8"           # Encoding to use throughout Gatling for file and string manipulation
     #simulationClass = ""         # The FQCN of the simulation to run (when used in conjunction with noReports, the simulation for which assertions will be validated)
-    #mute = false                 # When set to true, don't ask for simulation name nor run description (currently only used by Gatling SBT plugin)
-    #elFileBodiesCacheMaxCapacity = 200        # Cache size for request body EL templates, set to 0 to disable
-    #rawFileBodiesCacheMaxCapacity = 200       # Cache size for request body Raw templates, set to 0 to disable
-    #rawFileBodiesInMemoryMaxSize = 1000       # Below this limit, raw file bodies will be cached in memory
-
+    #elFileBodiesCacheMaxCapacity = 200      # Cache size for request body EL templates, set to 0 to disable
+    #rawFileBodiesCacheMaxCapacity = 200     # Cache size for request body raw files, set to 0 to disable
+    #rawFileBodiesInMemoryMaxSize = 1000     # Max bite size of raw files to be cached in memory
+    #pebbleFileBodiesCacheMaxCapacity = 200  # Cache size for request body Pebble templates, set to 0 to disable
+    #feederAdaptiveLoadModeThreshold = 100   # File size threshold (in MB). Below load eagerly in memory, above use batch mode with default buffer size
+    #shutdownTimeout = 10000                 # Milliseconds to wait for the actor system to shutdown
     extract {
       regex {
         #cacheMaxCapacity = 200 # Cache size for the compiled regexes, set to 0 to disable caching
@@ -24,20 +25,52 @@ gatling {
       }
       jsonPath {
         #cacheMaxCapacity = 200 # Cache size for the compiled jsonPath queries, set to 0 to disable caching
-        #preferJackson = false  # When set to true, prefer Jackson over Boon for JSON-related operations
       }
       css {
         #cacheMaxCapacity = 200 # Cache size for the compiled CSS selectors queries,  set to 0 to disable caching
       }
     }
-
     directory {
-      #data = user-files/data               # Folder where user's data (e.g. files used by Feeders) is located
-      #bodies = user-files/bodies           # Folder where bodies are located
-      #simulations = src/gatling/simulations/simulations # Folder where the bundle's simulations are located
+      #simulations = ""                     # If set, directory where simulation classes are located
+      #resources = ""                       # If set, directory where resources, such as feeder files and request bodies, are located
       #reportsOnly = ""                     # If set, name of report folder to look for in order to generate its report
       #binaries = ""                        # If set, name of the folder where compiles classes are located: Defaults to GATLING_HOME/target.
       #results = results                    # Name of the folder where all reports folder are located
+    }
+  }
+  socket {
+    #connectTimeout = 10000                 # Timeout in millis for establishing a TCP socket
+    #tcpNoDelay = true
+    #soKeepAlive = false                    # if TCP keepalive configured at OS level should be used
+    #soReuseAddress = false
+  }
+  netty {
+    #useNativeTransport = true              # if Netty Linux native transport should be used instead of Java NIO
+    #useIoUring = false                     # if io_uring should be used instead of epoll if available
+    #allocator = "pooled"                   # switch to unpooled for unpooled ByteBufAllocator
+    #maxThreadLocalCharBufferSize = 200000  # Netty's default is 16k
+  }
+  ssl {
+    #useOpenSsl = true                    # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
+    #useOpenSslFinalizers = false         # if OpenSSL contexts should be freed with Finalizer or if using RefCounted is fine
+    #handshakeTimeout = 10000             # TLS handshake timeout in millis
+    #useInsecureTrustManager = true       # Use an insecure TrustManager that trusts all server certificates
+    enabledProtocols = []             # Array of enabled protocols for HTTPS, if empty use Netty's defaults
+    #enabledCipherSuites = []          # Array of enabled cipher suites for HTTPS, if empty enable all available ciphers
+    #sessionCacheSize = 0              # SSLSession cache size, set to 0 to use JDK's default
+    #sessionTimeout = 0                # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
+    #enableSni = true                     # When set to true, enable Server Name indication (SNI)
+    keyStore {
+      #type = ""      # Type of SSLContext's KeyManagers store
+      #file = ""      # Location of SSLContext's KeyManagers store
+      #password = ""  # Password for SSLContext's KeyManagers store
+      #algorithm = "" # Algorithm used SSLContext's KeyManagers store
+    }
+    trustStore {
+      #type = ""      # Type of SSLContext's TrustManagers store
+      #file = ""      # Location of SSLContext's TrustManagers store
+      #password = ""  # Password for SSLContext's TrustManagers store
+      #algorithm = "" # Algorithm used by SSLContext's TrustManagers store
     }
   }
   charting {
@@ -57,61 +90,23 @@ gatling {
     #fetchedCssCacheMaxCapacity = 200          # Cache size for CSS parsed content, set to 0 to disable
     #fetchedHtmlCacheMaxCapacity = 200         # Cache size for HTML parsed content, set to 0 to disable
     #perUserCacheMaxCapacity = 200             # Per virtual user cache size, set to 0 to disable
-    #warmUpUrl = "http://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
-    #enableGA = true                           # Very light Google Analytics, please support
-    ssl {
-      keyStore {
-        #type = ""      # Type of SSLContext's KeyManagers store
-        #file = ""      # Location of SSLContext's KeyManagers store
-        #password = ""  # Password for SSLContext's KeyManagers store
-        #algorithm = "" # Algorithm used SSLContext's KeyManagers store
-      }
-      trustStore {
-        #type = ""      # Type of SSLContext's TrustManagers store
-        #file = ""      # Location of SSLContext's TrustManagers store
-        #password = ""  # Password for SSLContext's TrustManagers store
-        #algorithm = "" # Algorithm used by SSLContext's TrustManagers store
-      }
-    }
-    ahc {
-      #keepAlive = true                                # Allow pooling HTTP connections (keep-alive header automatically added)
-      #connectTimeout = 10000                          # Timeout when establishing a connection
-      #handshakeTimeout = 10000                        # Timeout when performing TLS hashshake
-      #pooledConnectionIdleTimeout = 60000             # Timeout when a connection stays unused in the pool
-      #readTimeout = 60000                             # Timeout when a used connection stays idle
-      #maxRetry = 2                                    # Number of times that a request should be tried again
-      #requestTimeout = 60000                          # Timeout of the requests
-      #acceptAnyCertificate = true                     # When set to true, doesn't validate SSL certificates
-      #httpClientCodecMaxInitialLineLength = 4096      # Maximum length of the initial line of the response (e.g. "HTTP/1.0 200 OK")
-      #httpClientCodecMaxHeaderSize = 8192             # Maximum size, in bytes, of each request's headers
-      #httpClientCodecMaxChunkSize = 8192              # Maximum length of the content or each chunk
-      #webSocketMaxFrameSize = 10240000                # Maximum frame payload size
-      #sslEnabledProtocols = [TLSv1.2, TLSv1.1, TLSv1] # Array of enabled protocols for HTTPS, if empty use the JDK defaults
-      #sslEnabledCipherSuites = []                     # Array of enabled cipher suites for HTTPS, if empty use the AHC defaults
-      #sslSessionCacheSize = 0                         # SSLSession cache size, set to 0 to use JDK's default
-      #sslSessionTimeout = 0                           # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
-      #useOpenSsl = false                              # if OpenSSL should be used instead of JSSE (requires tcnative jar)
-      #useNativeTransport = false                      # if native transport should be used instead of Java NIO (requires netty-transport-native-epoll, currently Linux only)
-      #tcpNoDelay = true
-      #soReuseAddress = false
-      #soLinger = -1
-      #soSndBuf = -1
-      #soRcvBuf = -1
-      #allocator = "pooled"                            # switch to unpooled for unpooled ByteBufAllocator
-      #maxThreadLocalCharBufferSize = 200000           # Netty's default is 16k
-    }
+    #warmUpUrl = "https://gatling.io"          # The URL to use to warm-up the HTTP stack (blank means disabled)
+    #pooledConnectionIdleTimeout = 60000       # Timeout in millis for a connection to stay idle in the pool
+    #requestTimeout = 60000                    # Timeout in millis for performing an HTTP request
+    #enableHostnameVerification = false        # When set to true, enable hostname verification: SSLEngine.setHttpsEndpointIdentificationAlgorithm("HTTPS")
     dns {
-      #queryTimeout = 5000                             # Timeout of each DNS query in millis
-      #maxQueriesPerResolve = 6                        # Maximum allowed number of DNS queries for a given name resolution
+      #queryTimeout = 5000                     # Timeout in millis of each DNS query in millis
+      #maxQueriesPerResolve = 6                # Maximum allowed number of DNS queries for a given name resolution
     }
   }
   jms {
-    #acknowledgedMessagesBufferSize = 5000             # size of the buffer used to tracked acknowledged messages and protect against duplicate receives
+    #replyTimeoutScanPeriod = 1000  # scan period for timedout reply messages
   }
   data {
-    #writers = [console, file]      # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite, jdbc)
+    #writers = [console, file]      # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite)
     console {
       #light = false                # When set to true, displays a light version without detailed request stats
+      #writePeriod = 5              # Write interval, in seconds
     }
     file {
       #bufferSize = 8192            # FileDataWriter's internal data buffer size, in bytes
@@ -125,8 +120,9 @@ gatling {
       #port = 2003                # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
       #protocol = "tcp"           # The protocol used to send data to Carbon (currently supported : "tcp", "udp")
       #rootPathPrefix = "gatling" # The common prefix of all metrics sent to Graphite
-      #bufferSize = 8192          # GraphiteDataWriter's internal data buffer size, in bytes
-      #writeInterval = 1          # GraphiteDataWriter's write interval, in seconds
+      #bufferSize = 8192          # Internal data buffer size, in bytes
+      #writePeriod = 1            # Write period, in seconds
     }
+    #enableAnalytics = true              # Anonymous Usage Analytics (no tracking), please support
   }
 }

--- a/src/gatling/resources/gatling.conf
+++ b/src/gatling/resources/gatling.conf
@@ -51,7 +51,7 @@ gatling {
     #maxThreadLocalCharBufferSize = 200000  # Netty's default is 16k
   }
   ssl {
-    useOpenSsl = true                    # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
+    #useOpenSsl = true                    # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
     #useOpenSslFinalizers = false         # if OpenSSL contexts should be freed with Finalizer or if using RefCounted is fine
     #handshakeTimeout = 10000             # TLS handshake timeout in millis
     #useInsecureTrustManager = true       # Use an insecure TrustManager that trusts all server certificates


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

When running upgraded Gatling repo on VM, the Java version specified in build.gradle was not being used and at runtime, the Java 1.8 was being used instead.  Java 1.8 does not support latest TLS 1.3 version therefore any https requests were failing.  This change specifies the use of a Java 11 version within the gradlew file that sets the JAVA_HOME to a Java installed locally on the VMs.  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ x] Yes
[ ] No
```
This may break local runs of the repo if the user does not have the Java 11 version installed on their machine
